### PR TITLE
Revert ButtonGroup to its old API

### DIFF
--- a/src/lib/ui/ButtonGroup.js
+++ b/src/lib/ui/ButtonGroup.js
@@ -1,11 +1,13 @@
 const
     React = require('react'),
-    {View, StyleSheet} = require('react-native')
+    {View, StyleSheet} = require('react-native'),
+    Button = require('./Button')
 
-const ButtonGroup = ({style: overrideStyles, children}) =>
+const ButtonGroup = ({style: overrideStyles, items, ...props}) =>
     <View
         style={StyleSheet.compose(style.container, overrideStyles)}
-        children={children}
+        children={items.map(btn =>
+            <Button key={btn.text} {...props} {...btn} />)}
     />
 
 const style = StyleSheet.create({

--- a/src/scenes/NewClaim/index.js
+++ b/src/scenes/NewClaim/index.js
@@ -150,18 +150,18 @@ const NewClaim = ({templateDid, projectDid}) => {
             {formSpecQuery.data.map(({id, title}) =>
                 <Text key={id} children={'- ' + title} />)}
 
-            <ButtonGroup style={{marginBottom: 100}}>
-                <Button
-                    type='outlined'
-                    text='Come back later'
-                    onPress={() => nav.navigateBack(1)}
-                />
-                <Button
-                    type='contained'
-                    text='Submit a Claim'
-                    onPress={() => toggleForm(true)}
-                />
-            </ButtonGroup>
+            <ButtonGroup
+                items={[{
+                    type: 'outlined',
+                    text: 'Come back later',
+                    onPress: () => nav.navigateBack(1),
+                }, {
+                    type: 'contained',
+                    text: 'Submit a Claim',
+                    onPress: () => toggleForm(true),
+                }]}
+                style={{marginBottom: 100}}
+            />
         </ScrollView>}
 
         <Modal


### PR DESCRIPTION
I was never onboard with this. And in the end, while I know this is a mainstream style, I don't think this is a good idea, at least not in this case.

I don't think in this specific case that the children API adds any benefits so I think it's better to proceed with the API that gives the user less freedom for now. Bigger API surface = More potential problems, more time documenting.
